### PR TITLE
🔀 :: (#9) - qr에서 ParticipantId를 파싱하는 것이 아닌 ExpoId를 파싱하도록 수정하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expoqrandroid/qr/view/QrScannerScreen.kt
+++ b/app/src/main/java/com/school_of_company/expoqrandroid/qr/view/QrScannerScreen.kt
@@ -100,19 +100,20 @@ internal fun QrScannerScreen(
 
                 QrcodeScanView(
                      onQrcodeScan = { qrContent ->
-                        try {
-                            val json = JSONObject(qrContent)
-                            val participantId = json.getString("participantId")
-                            val phoneNumber = json.getString("phoneNumber")
+                         try {
+                             val json = JSONObject(qrContent)
 
-                            val url = "https://startup-expo.kr/application/$participantId?formType=survey&userType=STANDARD&applicationType=register&phoneNumber=$phoneNumber"
-                            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                            context.startActivity(intent)
+                             val expoId = json.getString("expoId")
+                             val phoneNumber = json.getString("phoneNumber")
 
-                        } catch (e: Exception) {
-                            Log.e("QrScanner", "QR 파싱 실패", e)
-                            Toast.makeText(context, "QR 코드 파싱에 실패했습니다.", Toast.LENGTH_SHORT).show()
-                        }
+                             val url = "https://startup-expo.kr/application/$expoId?formType=survey&userType=STANDARD&applicationType=register&phoneNumber=$phoneNumber"
+                             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+                             context.startActivity(intent)
+
+                         } catch (e: Exception) {
+                             Log.e("QrScanner", "QR 파싱 실패", e)
+                             Toast.makeText(context, "박람회를 찾을 수 없습니다.", Toast.LENGTH_SHORT).show()
+                         }
                     },
                     lifecycleOwner = lifecycleOwner,
                     modifier = Modifier


### PR DESCRIPTION
## 💡 개요
- expoId가 아닌 participantId를 파싱하고 있어 폼 화면으로 이동이 되지 않는 문제가 있었습니다.
## 📃 작업내용
- qr에서 ParticipantId를 파싱하는 것이 아닌 ExpoId를 파싱하도록 수정하였습니다.
## 🔀 변경사항
- chore QrScannerScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x